### PR TITLE
Avoid “stoi: no conversion” when Windows newlines are present

### DIFF
--- a/Source/OBJ_Loader.h
+++ b/Source/OBJ_Loader.h
@@ -466,6 +466,10 @@ namespace objl
 			std::string curline;
 			while (std::getline(file, curline))
 			{
+				if ((curline.size() > 0) && (curline[curline.size() - 1] == '\r')) {
+					curline.resize(curline.size() - 1);
+				}
+
 				#ifdef OBJL_CONSOLE_OUTPUT
 				if ((outputIndicator = ((outputIndicator + 1) % outputEveryNth)) == 1)
 				{


### PR DESCRIPTION
While different platforms have different conventions for handling newlines, and `std::getline` only follows the convention of the current platform. Of course OBJ files could be created on one platform and read on another, which leads to problems.

Here's a bit of explanation:

https://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf

Adapted from the advice there, the fix is to trim the trailing `'\r'` when it's present.